### PR TITLE
Support for multiple projects

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 CERT_DIR=~/.letsencrypt_drupal
-TMP_DIR=/tmp/letsencrypt_drupal/$PROJECT_NAME
+TMP_DIR=/tmp/letsencrypt_drupal_$PROJECT_NAME
 FILE_BASECONFIG=${TMP_DIR}/baseconfig
 FILE_DRUSH_ALIAS=${TMP_DIR}/drush_alias
 FILE_DRUPAL_VERSION=${TMP_DIR}/drupal_version

--- a/functions.sh
+++ b/functions.sh
@@ -12,7 +12,6 @@ LOCK_FILENAME=/tmp/cert_renew_lock_${PROJECT_NAME}
 acquire_lock_or_exit()
 {
   # Check we are not running already: http://mywiki.wooledge.org/BashFAQ/045
-  # @ToDo: Platform specific lock.
   exec 8>${LOCK_FILENAME}
   if ! flock -n 8  ; then
     logline "Another instance of this script running.";

--- a/functions.sh
+++ b/functions.sh
@@ -1,18 +1,19 @@
 #!/usr/bin/env bash
 
 CERT_DIR=~/.letsencrypt_drupal
-TMP_DIR=/tmp/letsencrypt_drupal
+TMP_DIR=/tmp/letsencrypt_drupal/$PROJECT_NAME
 FILE_BASECONFIG=${TMP_DIR}/baseconfig
 FILE_DRUSH_ALIAS=${TMP_DIR}/drush_alias
 FILE_DRUPAL_VERSION=${TMP_DIR}/drupal_version
 FILE_PROJECT_ROOT=${TMP_DIR}/project_root
+LOCK_FILENAME=/tmp/cert_renew_lock_${PROJECT_NAME}
 
 #---------------------------------------------------------------------
 acquire_lock_or_exit()
 {
   # Check we are not running already: http://mywiki.wooledge.org/BashFAQ/045
   # @ToDo: Platform specific lock.
-  exec 8>/tmp/cert_renew_lock
+  exec 8>${LOCK_FILENAME}
   if ! flock -n 8  ; then
     logline "Another instance of this script running.";
     exit 1

--- a/functions.sh
+++ b/functions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 CERT_DIR=~/.letsencrypt_drupal
-TMP_DIR=/tmp/letsencrypt_drupal_$PROJECT_NAME
+TMP_DIR=/tmp/letsencrypt_drupal_${PROJECT_NAME}
 FILE_BASECONFIG=${TMP_DIR}/baseconfig
 FILE_DRUSH_ALIAS=${TMP_DIR}/drush_alias
 FILE_DRUPAL_VERSION=${TMP_DIR}/drupal_version

--- a/letsencrypt_drupal.sh
+++ b/letsencrypt_drupal.sh
@@ -18,6 +18,9 @@ DRUPAL_VERSION="$2"
 PROJECT_ROOT="$3"
 
 DRUSH_ALIAS_NO_AT="${DRUSH_ALIAS/@/}"
+PROJECT_NAME=$(echo "$DRUSH_ALIAS_NO_AT" | cut -d'.' -f1)
+PROJECT_ENV=$(echo "$DRUSH_ALIAS_NO_AT" | cut -d'.' -f2)
+
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DEHYDRATED="https://github.com/lukas2511/dehydrated.git"
 

--- a/letsencrypt_drupal.sh
+++ b/letsencrypt_drupal.sh
@@ -18,8 +18,10 @@ DRUPAL_VERSION="$2"
 PROJECT_ROOT="$3"
 
 DRUSH_ALIAS_NO_AT="${DRUSH_ALIAS/@/}"
-PROJECT_NAME=$(echo "$DRUSH_ALIAS_NO_AT" | cut -d'.' -f1)
-PROJECT_ENV=$(echo "$DRUSH_ALIAS_NO_AT" | cut -d'.' -f2)
+
+# We need to export these variables so functions.sh can use them.
+export PROJECT_NAME=$(echo "$DRUSH_ALIAS_NO_AT" | cut -d'.' -f1)
+export PROJECT_ENV=$(echo "$DRUSH_ALIAS_NO_AT" | cut -d'.' -f2)
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DEHYDRATED="https://github.com/lukas2511/dehydrated.git"


### PR DESCRIPTION
This PR makes the following changes:

* Picks up the name of the current project and uses it as the basis for the lockfile -- thereby allowing multiple projects on the same tenant to have certificates handled.
* Exposes a parameter which accepts any switches to be passed through to Dehydrated -- such as `-x`.